### PR TITLE
Add getter and setter methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    column_hider (0.0.3)
+    column_hider (0.1.0)
       rails (~> 4.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ The solution to this problem lies in overriding the `ActiveRecord` columns metho
 
   ```ruby  
     extend ColumnHider::ActiveRecordAttributes   
-    column_hider_columns :column_one
+    column_hider_deprecate_columns :column_one, :column_two, ...
   ```   
 
   where `:column_one` is the `CTBD`.
 
-  This logically deletes the column from the application - whenever the application accesses the model, the column will be removed from the list of columns that the application knows about.
+  This logically deletes the column from the application - whenever the application accesses the model, the column will be removed from the list of columns that the application knows about. Getter and setter methods are dynamically added, so that you'll receive NoMethodError errors if you try to use the `CTBD` anywhere in your application.   
 
   Then go through your application in the normal way and remove all other references to the `CTBD`.
 

--- a/lib/column_hider.rb
+++ b/lib/column_hider.rb
@@ -7,6 +7,9 @@ module ColumnHider
   # To use, add two lines to your model:
   # `  extend ColumnHider::ActiveRecordAttributes`
   # `  column_hider_columns :column_one, :column_two, ...`
+  # If you want to deprecate the columns, call:
+  # `  column_hider_deprecate_columns :column_one, :column_two, ...`
+  #    This will also hide the columns
   #
   module ActiveRecordAttributes
     def column_hider_columns(*cols)
@@ -20,6 +23,19 @@ module ColumnHider
       @column_hider_columns ||= {} # just in case the model has "extend ColumnHider::ActiveRecordAttributes", but doesn't call column_hider_columns
       super.reject { |col| @column_hider_columns.has_key?(col.name.to_sym) }
     end
+
+    def column_hider_deprecate_columns(*cols)
+      cols.each do |c|
+        define_method("#{c}".to_sym) do
+          raise NoMethodError.new("column '#{c}' deprecated", c.to_sym)
+        end
+        define_method("#{c}=".to_sym) do |arg|
+          raise NoMethodError.new("column '#{c}' deprecated", c.to_sym)
+        end
+      end
+      column_hider_columns(*cols)
+    end
+
   end
 
 end

--- a/lib/column_hider/version.rb
+++ b/lib/column_hider/version.rb
@@ -1,3 +1,3 @@
 module ColumnHider
-  VERSION = "0.0.3"
+  VERSION = "0.1.0"
 end

--- a/test/column_hider_test.rb
+++ b/test/column_hider_test.rb
@@ -17,6 +17,7 @@ describe ColumnHider do
       end
       extend ColumnHider::ActiveRecordAttributes
       column_hider_columns :capital
+      column_hider_deprecate_columns :capital
     end
   end
 
@@ -37,9 +38,16 @@ describe ColumnHider do
       expect(col_arr).wont_include('capital')
     end
 
-    it '#raises an error if we reference a hidden column' do
-      assert_raises ActiveRecord::UnknownAttributeError do
+    it '#raises an error if we reference a hidden column via mass assignment' do
+      assert_raises NoMethodError do
         c = Country.new(name: 'USA', capital: 'Washington, DC', comment: 'America')
+      end
+    end
+
+    it '#raises an error if we reference a hidden column via individual assignment' do
+      assert_raises NoMethodError do
+        c = Country.new
+        c.capital = 'Edinburgh'
       end
     end
   end


### PR DESCRIPTION
These will raise a NoMethodError if you try to reference a hidden column.

A new method is added to the gem - `column_hider_deprecate_columns`.
This method dynamically adds the getter and setter methods, and also calls the `column_hider_columns` method. 

The calling application only needs to call `column_hider_deprecate_columns`. Existing uses of the `column_hider_columns` method will remain unchanged.
